### PR TITLE
Search

### DIFF
--- a/chrome/content/zotero-better-bibtex/schomd.coffee
+++ b/chrome/content/zotero-better-bibtex/schomd.coffee
@@ -67,6 +67,12 @@ Zotero.BetterBibTeX.schomd.init = ->
   }
   return
 
+Zotero.BetterBibTeX.schomd.item = (citekeys) ->
+  citekeys = [citekeys] unless Array.isArray(citekeys)
+  return '' if citekeys.length == 0
+  vars = ('?' for citekey in citekeys).join(',')
+  return Zotero.BetterBibTeX.DB.columnQuery("select itemID from keys where citekey in (#{vars})", citekeys)
+
 Zotero.BetterBibTeX.schomd.citation = (stylename, citekeys) ->
   citekeys = [citekeys] unless Array.isArray(citekeys)
   return '' if citekeys.length == 0


### PR DESCRIPTION
I am writing a [Zotero plugin for Adobe Brackets][1] and it makes heavy use of [Better BibTeX][2]. Right now I am running a [forked][3] version of [Better BibTeX][2] with some custom additions that my plugin needs. I am submitting this pull request in the hope that these changes would land in the main plugin and I won't have to maintain a fork.

**NOTE: _I have not changed existing code, just added a few more methods and endpoints that [brackets-zotero][1] plugin needs._**

# Changes to schomd.coffee

1. **Added a new method `Zotero.BetterBibTeX.schomd.item`**.

  It takes bibtex keys and return item IDs. Actually this method has been factored out of `Zotero.BetterBibTeX.schomd.citation` and `Zotero.BetterBibTeX.schomd.bibliography`. I have not changed existing methods to facilitate a clean merge. If you decide to merge, then maybe you can use this method in `citation` and `bibliography` to remove code duplication.

# Changes to web-endpoints.coffee

1. **Added endpoint `Zotero.BetterBibTeX.endpoints.search`**.  

  Provides Querying capabilities over the entire Zotero library.

  Query is specified as shown below:
  
  ```H
  http://localhost:23119/better-bibtex/search?query=medical
  ```

  Response looks like this:

  ```json
  [{
    "id": 7,
    "key": "V6MU8MV8",
    "libraryKey": "0/V6MU8MV8",
    "title": "Aims and tasks of medical informatics",
    "date": "1997",
    "extra": "bibtex: Haux1997",
    "creators": [{
        "lastName": "Haux",
        "firstName": "Reinhold"
    }]
  }]
  ```

2. **Added endpoint `Zotero.BetterBibTeX.endpoints.item`**.

  Takes an array of either bibTeX keys or item IDs and returns bibTeX rendition of these items.

  POST body looks like this

  ```json
  {"translator": "betterbiblatex", "format": "text", "bibtexKeys":["Eysenbach2004", "Gustafson2002"]}
  ```

  or like this

  ```json
  {"translator": "betterbiblatex", "format": "json", "ids":[1, 4, 17, 20]}
  ```

  Response looks like this in case of `text` format

  ```text
  @article{Eysenbach2004,
  title = {Tackling publication bias and selective reporting in health informatics research: register your {eHealth} trials in the {International} {eHealth} {Studies} {Registry}},
  volume = {6},
  url = {http://www.ncbi.nlm.nih.gov/pmc/articles/PMC1550610/},
  shorttitle = {Tackling publication bias and selective reporting in health informatics research},
  number = {3},
  journaltitle = {Journal of medical {Internet} research},
  shortjournal = {J. {Med}. {Internet} {Res}.},
  author = {Eysenbach, Gunther},
  urldate = {2015-01-21},
  date = {2004},
  file = {[HTML] from nih.gov:/home/wasif/.mozilla/firefox/8sq2ycer.default/zotero/storage/KFZIM4RZ/PMC1550610.html:text/html;[HTML] from nih.gov:/home/wasif/.mozilla/firefox/8sq2ycer.default/zotero/storage/KWD5MT5F/PMC1550610.html:text/html}
}

@article{Gustafson2002,
  title = {{CHESS}: 10 years of research and development in consumer health informatics for broad populations, including the underserved},
  volume = {65},
  url = {http://www.sciencedirect.com/science/article/pii/S1386505602000485},
  shorttitle = {{CHESS}},
  number = {3},
  journaltitle = {International journal of medical informatics},
  shortjournal = {Int. {J}. {Med}. {Inf}.},
  author = {Gustafson, David H. and Hawkins, Robert P. and Boberg, Eric W. and McTavish, Fiona and Owens, Betta and Wise, Meg and Berhe, Haile and Pingree, Suzanne},
  urldate = {2015-01-21},
  date = {2002},
  pages = {169--177},
  file = {[PDF] from ucsf.edu:/home/wasif/.mozilla/firefox/8sq2ycer.default/zotero/storage/F42SCQF4/Gustafson et al. - 2002 - CHESS 10 years of research and development in con.pdf:application/pdf;[PDF] from ucsf.edu:/home/wasif/.mozilla/firefox/8sq2ycer.default/zotero/storage/GA5WMFUC/Gustafson et al. - 2002 - CHESS 10 years of research and development in con.pdf:application/pdf;Snapshot:/home/wasif/.mozilla/firefox/8sq2ycer.default/zotero/storage/UDK8UJEN/abstract.html:text/html;Snapshot:/home/wasif/.mozilla/firefox/8sq2ycer.default/zotero/storage/VQ2HX5FU/S1386505602000485.html:text/html}
}



  ```

  or like this in case of `json` format

  ```json
  [
    {
        "id": 8,
        "key": "22J6NQEX",
        "bibtex": "\n@article{Eysenbach2004,\n  title = {Tackling publication bias..."
    },
    {
        "id": 4,
        "key": "7IV65BT6",
        "bibtex": "\n@article{Gustafson2002,\n  title = {{CHESS}: 10 years of research and development..."
    }
]
  ```

[1]: https://github.com/baig/brackets-zotero
[2]: https://github.com/ZotPlus/zotero-better-bibtex
[3]: https://github.com/baig/zotero-better-bibtex/tree/search