### PR TITLE
Modified schomd.items to return an Array of Zotero Items, not just Array...

### DIFF
--- a/chrome/content/zotero-better-bibtex/schomd.coffee
+++ b/chrome/content/zotero-better-bibtex/schomd.coffee
@@ -76,9 +76,9 @@ Zotero.BetterBibTeX.schomd.items = (citekeys, {library}) ->
       ids.push(key)
     else
       keys.push(key)
-  return ids if keys.length == 0
+  return Zotero.Items.get(ids) if keys.length == 0
   vars = ('?' for citekey in keys).join(',')
-  return ids.concat(Zotero.BetterBibTeX.DB.columnQuery("select itemID from keys where citekey in (#{vars}) and libraryID = ?", keys.concat([library || 0])))
+  return Zotero.Items.get(ids.concat(Zotero.BetterBibTeX.DB.columnQuery("select itemID from keys where citekey in (#{vars}) and libraryID = ?", keys.concat([library || 0]))))
 
 Zotero.BetterBibTeX.schomd.citation = (citekeys, {style, library}) ->
   items = @items(citekeys, {library: library})


### PR DESCRIPTION
I believe all other methods (`citation`, `bibliography`, and `bibtex`) expect `items` method to return an array of Zotero Items not just an array of item IDs.

UPDATE: I just found out they don't. You can reject this pull request. I need to change only `bibtex` to return Zotero Items