### PR TITLE
Wrapped call to @items inside Zotero.Items.get; Made 2nd argument option...

### DIFF
--- a/chrome/content/zotero-better-bibtex/schomd.coffee
+++ b/chrome/content/zotero-better-bibtex/schomd.coffee
@@ -130,8 +130,8 @@ Zotero.BetterBibTeX.schomd.search = (term) ->
       )
     } for item in Zotero.Items.get(results))
 
-Zotero.BetterBibTeX.schomd.bibtex = (keys, {translator, format, library, displayOptions}) ->
-  items = @items(keys, {library: library})
+Zotero.BetterBibTeX.schomd.bibtex = (keys, {translator, format, library, displayOptions} = {}) ->
+  items = Zotero.Items.get(@items(keys, {library: library}))
   translator ?= 'betterbiblatex'
   format ?= 'json'
   displayOptions ?= {}


### PR DESCRIPTION
Wrapped call to `@items(...)` inside `Zotero.Items.get`.

Also made 2nd argument optional since it allows for nice POST body like this

```json
{"method":"bibtex","params":[["Eysenbach2004", "Gustafson2002"]]}
```

instead of this

```json
{"method":"bibtex","params":[["Eysenbach2004", "Gustafson2002"], {}]}
```