### PR TITLE
New substring filter for custom BibTeX keys

### DIFF
--- a/chrome/content/zotero-better-bibtex/BetterBibTeXPatternFormatter.coffee
+++ b/chrome/content/zotero-better-bibtex/BetterBibTeXPatternFormatter.coffee
@@ -301,7 +301,7 @@ class BetterBibTeXPatternFormatter
       return value.slice(start, end).join(' ')
 
     substring: (value, start, n) ->
-      return value.slice(start - 1, start - 1 + n)
+      return (value || '').slice(start - 1, start - 1 + n)
 
     ascii: (value) ->
       return (value || '').replace(/[^ -~]/g, '').split(/\s+/).join(' ').trim()

--- a/chrome/content/zotero-better-bibtex/BetterBibTeXPatternFormatter.coffee
+++ b/chrome/content/zotero-better-bibtex/BetterBibTeXPatternFormatter.coffee
@@ -300,6 +300,9 @@ class BetterBibTeXPatternFormatter
       end = start + parseInt(n) if typeof n != 'undefined'
       return value.slice(start, end).join(' ')
 
+    substring: (value, start, n) ->
+      return value.slice(start - 1, start - 1 + n)
+
     ascii: (value) ->
       return (value || '').replace(/[^ -~]/g, '').split(/\s+/).join(' ').trim()
 


### PR DESCRIPTION
This is just a small feature enhancement, which adds a substring filter for creating BibTeX keys. It takes two arguments x and y and returns the substring of length y starting at position x of the input string.