### PR TITLE
Fix typo stature->statute (zotero item type)

### DIFF
--- a/resource/translators/Better BibLaTeX.coffee
+++ b/resource/translators/Better BibLaTeX.coffee
@@ -34,7 +34,7 @@ Translator.typeMap = {
   '=online':                          'blogPost forumPost webpage'
   inproceedings:                      'conferencePaper'
   report:                             'report'
-  legislation:                        'stature bill'
+  legislation:                        'statute bill'
   jurisdiction:                       'case hearing'
   patent:                             'patent'
   audio:                              'audioRecording podcast'


### PR DESCRIPTION
Zotero's Bill and Statute types are @legislation in BibLaTeX.