### PR TITLE
Fix delimiter between citations

### DIFF
--- a/chrome/content/zotero-better-bibtex/cayw.coffee
+++ b/chrome/content/zotero-better-bibtex/cayw.coffee
@@ -80,7 +80,7 @@ class Zotero.BetterBibTeX.CAYW.CitationEditInterface
       citepostfix: ''
       keyprefix: ''
       keypostfix: ''
-      separator: ','
+      separator: ';'
       clipboard: false
       format: ''
     }


### PR DESCRIPTION
A comma won't work (at least for pandoc), it needs to be a semicolon. This is also more usual for autor-date styles.