### PR TITLE
New jsonrpc endpoints for bibliographyhtml and bibliographybbl

### DIFF
--- a/chrome/content/zotero-better-bibtex/schomd.coffee
+++ b/chrome/content/zotero-better-bibtex/schomd.coffee
@@ -191,10 +191,10 @@ Zotero.BetterBibTeX.schomd.citation = (citekeys, {style, libraryID} = {}) ->
 
   return '' if itemIDs.length == 0
 
-  urlstyle = "#{style ? 'apa'}"
-  style = Zotero.Styles.get("http://www.zotero.org/styles/#{urlstyle}")
-  style = Zotero.Styles.get("http://juris-m.github.io/styles/#{urlstyle}") unless style != false
-  style = Zotero.Styles.get("#{urlstyle}") unless style != false
+  styleurl = "#{style ? 'apa'}"
+  style = Zotero.Styles.get("http://www.zotero.org/styles/#{styleurl}")
+  style = Zotero.Styles.get("http://juris-m.github.io/styles/#{styleurl}") unless style != false
+  style = Zotero.Styles.get("#{styleurl}") unless style != false
   cp = style.getCiteProc()
   cp.setOutputFormat('markdown')
   cp.updateItems(itemIDs)
@@ -208,10 +208,10 @@ Zotero.BetterBibTeX.schomd.bibliography = (citekeys, {style, libraryID} = {}) ->
   itemIDs = @itemIDs(citekeys, {libraryID})
   return '' if itemIDs.length == 0
 
-  urlstyle = "#{style ? 'apa'}"
-  style = Zotero.Styles.get("http://www.zotero.org/styles/#{urlstyle}")
-  style = Zotero.Styles.get("http://juris-m.github.io/styles/#{urlstyle}") unless style != false
-  style = Zotero.Styles.get("#{urlstyle}") unless style != false
+  styleurl = "#{style ? 'apa'}"
+  style = Zotero.Styles.get("http://www.zotero.org/styles/#{styleurl}")
+  style = Zotero.Styles.get("http://juris-m.github.io/styles/#{styleurl}") unless style != false
+  style = Zotero.Styles.get("#{styleurl}") unless style != false
   cp = style.getCiteProc()
   cp.setOutputFormat('markdown')
   cp.updateItems((item for item in itemIDs when item))
@@ -224,10 +224,10 @@ Zotero.BetterBibTeX.schomd.bibliographyhtml = (citekeys, {style, libraryID} = {}
   itemIDs = @itemIDs(citekeys, {libraryID})
   return '' if itemIDs.length == 0
 
-  urlstyle = "#{style ? 'apa'}"
-  style = Zotero.Styles.get("http://www.zotero.org/styles/#{urlstyle}")
-  style = Zotero.Styles.get("http://juris-m.github.io/styles/#{urlstyle}") unless style != false
-  style = Zotero.Styles.get("#{urlstyle}") unless style != false
+  styleurl = "#{style ? 'apa'}"
+  style = Zotero.Styles.get("http://www.zotero.org/styles/#{styleurl}")
+  style = Zotero.Styles.get("http://juris-m.github.io/styles/#{styleurl}") unless style != false
+  style = Zotero.Styles.get("#{styleurl}") unless style != false
   cp = style.getCiteProc()
   cp.setOutputFormat('html')
   cp.updateItems((item for item in itemIDs when item))
@@ -240,10 +240,10 @@ Zotero.BetterBibTeX.schomd.bibliographybbl = (citekeys, {style, libraryID} = {})
   itemIDs = @itemIDs(citekeys, {libraryID})
   return '' if itemIDs.length == 0
 
-  urlstyle = "#{style ? 'apa'}"
-  style = Zotero.Styles.get("http://www.zotero.org/styles/#{urlstyle}")
-  style = Zotero.Styles.get("http://juris-m.github.io/styles/#{urlstyle}") unless style != false
-  style = Zotero.Styles.get("#{urlstyle}") unless style != false
+  styleurl = "#{style ? 'apa'}"
+  style = Zotero.Styles.get("http://www.zotero.org/styles/#{styleurl}")
+  style = Zotero.Styles.get("http://juris-m.github.io/styles/#{styleurl}") unless style != false
+  style = Zotero.Styles.get("#{styleurl}") unless style != false
   cp = style.getCiteProc()
   cp.setOutputFormat('bbl')
   cp.updateItems((item for item in itemIDs when item))

--- a/chrome/content/zotero-better-bibtex/web-endpoints.coffee
+++ b/chrome/content/zotero-better-bibtex/web-endpoints.coffee
@@ -127,7 +127,7 @@ Zotero.BetterBibTeX.endpoints.schomd.init = (url, data, sendResponseCallback) ->
 
   try
     switch req.method
-      when 'citations', 'citation', 'bibliography', 'bibtex', 'search'
+      when 'citations', 'citation', 'bibliography', 'bibliographyhtml', 'bibliographybbl', 'bibtex', 'search'
         ### the schomd methods search by citekey -- the cache needs to be fully primed for this to work ###
         Zotero.BetterBibTeX.keymanager.prime()
 


### PR DESCRIPTION
These changes are tested and working.

I added the guard in the text_escape that we discussed, to remove the extraneous string "undefined" that would appear in the bbl output. I don't know why it did not appear in the corresponding markdown output, but added it anyway just to be sure. It occurs in the HTML output prototype in citeproc.js; in fact, that's where I learned it from.

I modified the way that the style file is located so that Juris-M styles such as jm-babyblue are found by it. Without that, it can not find them, since they have a different base URL. Actually, the Juris-M code did not have it's own style ID base URL's in it either; I've made a patch for that that I hope they accept. If the short URL does not work, try passing the entire thing, including the http://juris-m.github.io/style/ part, and I think this code will find it even without that patch to Juris-M. I think it will still work fine with regular Zotero, and in fact, the style will likely be set after the first call to Zotero.Styles.get().

It can now return an HTML formatted bibliography, as well as a .bbl formatted one, allowing it to be a component of a drop-in replacement for "bibtex". See my "zotero-texmacs-integration" repo for that. (pushing that shortly after creating this pull request.) That was tested and is working. I was able to use it to obtain a Juris-M Babyblue formatted bibliography, something that no LaTeX bibliography style has available. Next up is the formatting of the inline citations via cayw, but I may not have time to complete that work for several weeks or even a month or two due to more pressing higher-priority demands on my time.