### PR TITLE
Also omit square brackets for Pandoc Citation in CAYW

### DIFF
--- a/chrome/content/zotero-better-bibtex/cayw.coffee
+++ b/chrome/content/zotero-better-bibtex/cayw.coffee
@@ -202,7 +202,6 @@ Zotero.BetterBibTeX.CAYW.Formatter = {
       cite += ", #{Zotero.BetterBibTeX.CAYW.shortLocator[citation.label]} #{citation.locator}" if citation.locator
       cite += " #{citation.suffix}" if citation.suffix
       formatted.push(cite)
-    return '' if formatted.length == 0
     return formatted.join('; ')
 
   'scannable-cite': (citations) ->

--- a/chrome/content/zotero-better-bibtex/cayw.coffee
+++ b/chrome/content/zotero-better-bibtex/cayw.coffee
@@ -203,7 +203,7 @@ Zotero.BetterBibTeX.CAYW.Formatter = {
       cite += " #{citation.suffix}" if citation.suffix
       formatted.push(cite)
     return '' if formatted.length == 0
-    return '[' + formatted.join('; ') + ']'
+    return formatted.join('; ')
 
   'scannable-cite': (citations) ->
 

--- a/resource/tests/export.feature
+++ b/resource/tests/export.feature
@@ -175,7 +175,7 @@ Scenario: CAYW picker
   And I pick 'A bicycle made for two? The integration of scientific techniques into archaeological interpretation' for CAYW:
     | label | chapter |
     | locator | 1 |
-  Then the picks for pandoc should be '[@bentley_academic_2011, p. 1; @pollard_bicycle_2007, ch. 1]'
+  Then the picks for pandoc should be '@bentley_academic_2011, p. 1; @pollard_bicycle_2007, ch. 1'
   And the picks for mmd should be '[#bentley_academic_2011][][#pollard_bicycle_2007][]'
   And the picks for latex should be '\cite[1]{bentley_academic_2011}\cite[ch. 1]{pollard_bicycle_2007}'
   And the picks for scannable-cite should be '{|Abram, 2014|p. 1||zu:0:ITEMKEY}{|Pollard and Bray, 2007|ch. 1||zu:0:ITEMKEY}'


### PR DESCRIPTION
Incorporate the change proposed in #358 and implemented in 8b260cb to CAYW as well.